### PR TITLE
Robustify adapt to work with random charm++ queues

### DIFF
--- a/src/Cello/cello.cpp
+++ b/src/Cello/cello.cpp
@@ -447,6 +447,11 @@ namespace cello {
 
   //----------------------------------------------------------------------
 
+  int num_children(Block * block)
+  { return block->is_leaf() ? 0 : num_children(); }
+
+  //----------------------------------------------------------------------
+
   size_t num_blocks_process()
   {
     return hierarchy() ? hierarchy()->num_blocks() : 0;

--- a/src/Cello/cello.hpp
+++ b/src/Cello/cello.hpp
@@ -815,6 +815,7 @@ namespace cello {
   /// Return the number of children each Block may have
   int             num_children();
   int             num_children(int rank);
+  int             num_children(Block * block);
   /// Return the number of Blocks on this process
   size_t          num_blocks_process();
   /// Return the cell volume at the given level relative to the root level

--- a/src/Cello/charm_MsgAdapt.cpp
+++ b/src/Cello/charm_MsgAdapt.cpp
@@ -41,6 +41,7 @@ void * MsgAdapt::pack (MsgAdapt * msg)
   SIZE_SCALAR_TYPE(size,int,   msg->level_min_);
   SIZE_SCALAR_TYPE(size,int,   msg->level_max_);
   SIZE_SCALAR_TYPE(size,bool,  msg->can_coarsen_);
+  SIZE_SCALAR_TYPE(size,int,   msg->count_);
   SIZE_ARRAY_TYPE(size,char,msg->tag_,TAG_LEN+1);
 
   //--------------------------------------------------
@@ -65,6 +66,7 @@ void * MsgAdapt::pack (MsgAdapt * msg)
   SAVE_SCALAR_TYPE(pc,int,   msg->level_min_);
   SAVE_SCALAR_TYPE(pc,int,   msg->level_max_);
   SAVE_SCALAR_TYPE(pc,bool,  msg->can_coarsen_);
+  SAVE_SCALAR_TYPE(pc,int,   msg->count_);
   SAVE_ARRAY_TYPE(pc,char,msg->tag_,TAG_LEN+1);
   
   ASSERT2("MsgAdapt::pack()",
@@ -106,6 +108,7 @@ MsgAdapt * MsgAdapt::unpack(void * buffer)
   LOAD_SCALAR_TYPE(pc,int,   msg->level_min_);
   LOAD_SCALAR_TYPE(pc,int,   msg->level_max_);
   LOAD_SCALAR_TYPE(pc,bool,  msg->can_coarsen_);
+  LOAD_SCALAR_TYPE(pc,int,   msg->count_);
   LOAD_ARRAY_TYPE(pc,char,msg->tag_,TAG_LEN+1);
 
   // 3. Save the input buffer for freeing later

--- a/src/Cello/charm_MsgAdapt.hpp
+++ b/src/Cello/charm_MsgAdapt.hpp
@@ -34,7 +34,8 @@ public: // interface
    int level_now,
    int level_min,
    int level_max,
-   bool can_coarsen
+   bool can_coarsen,
+   int count
    )
     :
     adapt_step_(adapt_step),
@@ -43,6 +44,7 @@ public: // interface
     level_min_(level_min),
     level_max_(level_max),
     can_coarsen_(can_coarsen),
+    count_(count),
     buffer_(nullptr)
   {
     cello::hex_string(tag_,TAG_LEN); // add new tag for new message
@@ -103,6 +105,7 @@ protected: // attributes
   int level_min_;
   int level_max_;
   bool can_coarsen_;
+  int count_;
   /// Saved Charm++ buffer for deleting after unpack()
   void * buffer_;
   /// Random hex tag for tracking messages for debugging

--- a/src/Cello/charm_MsgCoarsen.cpp
+++ b/src/Cello/charm_MsgCoarsen.cpp
@@ -22,7 +22,8 @@ MsgCoarsen::MsgCoarsen()
     buffer_(NULL),
     adapt_child_(nullptr),
     num_face_level_(0),
-    face_level_(NULL)
+    face_level_(NULL),
+    face_level_count_(NULL)
 {
   ic3_[0] = ic3_[1] = ic3_[2] = -1;
   ++counter[cello::index_static()]; 
@@ -33,6 +34,7 @@ MsgCoarsen::MsgCoarsen()
 MsgCoarsen::MsgCoarsen
 (int num_face_level,
  std::vector<int> & face_level,
+ std::vector<int> & face_level_count,
  int ic3[3],
  Adapt * adapt_child)
   : CMessage_MsgCoarsen(),
@@ -41,13 +43,15 @@ MsgCoarsen::MsgCoarsen
     buffer_(NULL),
     adapt_child_(adapt_child),
     num_face_level_(num_face_level),
-    face_level_(new int[num_face_level])
+    face_level_(new int[num_face_level]),
+    face_level_count_(new int[num_face_level])
 {
 
   ++counter[cello::index_static()]; 
 
   for (int i=0; i<num_face_level_; i++) {
     face_level_[i] = face_level[i];
+    face_level_count_[i] = -1;
   }
   ic3_[0]=ic3[0];
   ic3_[1]=ic3[1];
@@ -61,9 +65,11 @@ MsgCoarsen::~MsgCoarsen()
   --counter[cello::index_static()];
 
   delete data_msg_;
-  data_msg_ = 0;
+  data_msg_ = nullptr;
   delete [] face_level_;
-  face_level_ = 0;
+  face_level_ = nullptr;
+  delete [] face_level_count_;
+  face_level_count_ = nullptr;
   CkFreeMsg (buffer_);
   buffer_=nullptr;
 }
@@ -99,6 +105,9 @@ void * MsgCoarsen::pack (MsgCoarsen * msg)
   size += sizeof(int);
 
   // face_level_[]
+  size += msg->num_face_level_ * sizeof(int);
+
+  // face_level_count_[]
   size += msg->num_face_level_ * sizeof(int);
 
   // ic3_[]
@@ -138,6 +147,10 @@ void * MsgCoarsen::pack (MsgCoarsen * msg)
   // face_level_[]
   for (int i=0; i<msg->num_face_level_; i++) {
     (*pi++) = msg->face_level_[i];
+  }
+  // face_level_count_[]
+  for (int i=0; i<msg->num_face_level_; i++) {
+    (*pi++) = msg->face_level_count_[i];
   }
 
   // ic3_[]
@@ -205,7 +218,17 @@ MsgCoarsen * MsgCoarsen::unpack(void * buffer)
       msg->face_level_[i] = (*pi++);
     }
   } else {
-    msg->face_level_ = 0;
+    msg->face_level_ = nullptr;
+  }
+
+  // face_level_count_[]
+  if (msg->num_face_level_ > 0) {
+    msg->face_level_count_ = new int [msg->num_face_level_];
+    for (int i = 0; i<msg->num_face_level_; i++) {
+      msg->face_level_count_[i] = (*pi++);
+    }
+  } else {
+    msg->face_level_count_ = nullptr;
   }
 
   // ic3_[]

--- a/src/Cello/charm_MsgCoarsen.hpp
+++ b/src/Cello/charm_MsgCoarsen.hpp
@@ -27,7 +27,10 @@ public: // interface
 
   MsgCoarsen();
 
-  MsgCoarsen( int num_face_level, std::vector<int> & face_level, int ic3[3],
+  MsgCoarsen( int num_face_level,
+              std::vector<int> & face_level,
+              std::vector<int> & face_level_count,
+              int ic3[3],
               Adapt * adapt_child);
 
   virtual ~MsgCoarsen();
@@ -53,6 +56,8 @@ public: // interface
 
   /// Return the face_level_ attribute
   int * face_level() { return face_level_; }
+  /// Return the face_level_count_ attribute
+  int * face_level_count() { return face_level_count_; }
 
   Adapt * adapt_child() const { return adapt_child_; }
   
@@ -82,6 +87,7 @@ protected: // attributes
 
   int num_face_level_;
   int * face_level_;
+  int * face_level_count_;
   int ic3_[3];
 
 };

--- a/src/Cello/control_initialize.cpp
+++ b/src/Cello/control_initialize.cpp
@@ -71,16 +71,6 @@ void Simulation::initialize() throw()
     block_array = hierarchy_->new_block_proxy (allocate_data);
     thisProxy.p_set_block_array(block_array);
   }
-
-  CkCallback callback 
-    (CkIndex_Simulation::r_initialize_block_array(NULL), thisProxy);
-
-  // --------------------------------------------------
-#ifdef TRACE_CONTRIBUTE  
-  CkPrintf ("%s:%d DEBUG_CONTRIBUTE r_initialize_block_array()\n",__FILE__,__LINE__); fflush(stdout);
-#endif  
-  contribute(0,0,CkReduction::concat,callback);
-  // --------------------------------------------------
 }
 
 //----------------------------------------------------------------------

--- a/src/Cello/mesh.ci
+++ b/src/Cello/mesh.ci
@@ -95,7 +95,7 @@ module mesh {
 
   array[Index] Block {
 
-    entry Block (process_type ip_source,  MsgType msg_type);
+    entry Block (MsgType msg_type);
     entry void p_set_msg_refine(MsgRefine * msg);
     entry Block();
 

--- a/src/Cello/mesh_Block.cpp
+++ b/src/Cello/mesh_Block.cpp
@@ -36,7 +36,7 @@ const char * phase_name[] = {
 
 // #define TRACE_BLOCK
 
-Block::Block ( process_type ip_source, MsgType msg_type )
+Block::Block ( MsgType msg_type )
   : CBase_Block(),
     data_(NULL),
     child_data_(NULL),
@@ -51,8 +51,8 @@ Block::Block ( process_type ip_source, MsgType msg_type )
     sync_count_(),
     sync_max_(),
     adapt_(),
-    child_face_level_curr_(),
-    child_face_level_next_(),
+    child_face_level_curr_count_(),
+    child_face_level_next_count_(),
     count_coarsen_(0),
     adapt_step_(0),
     adapt_ready_(false),
@@ -180,13 +180,14 @@ void Block::init_refine_
 
   // Initialize neighbor face levels
 
+  const int nc = cello::num_children();
+
   if (num_face_level == 0) {
 
-    child_face_level_curr_.resize(cello::num_children()*27);
+    child_face_level_curr_.resize(nc*27);
 
-    adapt_.reset_face_level (Adapt::LevelType::curr);
-
-    // Compute and set the face levels of
+    adapt_.reset_face_level_curr();
+   // Compute and set the face levels of
     int if3[3], na3[3], face_levels[27] = {};
     size_array(na3,na3+1,na3+2);
     ItFace it_face = this->it_face(cello::config()->adapt_min_face_rank, index_);
@@ -195,18 +196,26 @@ void Block::init_refine_
       bool refine = refine_during_initialization(neighbor_index);
       face_levels[IF3(if3)] = refine ? 1 : 0;
     }
-    adapt_.copy_face_level(Adapt::LevelType::curr, face_levels);
-
+    adapt_.copy_face_level_curr(face_levels);
   } else {
 
-    child_face_level_curr_.resize(cello::num_children()*num_face_level);
+    child_face_level_curr_.resize(nc*num_face_level);
 
-    adapt_.copy_face_level(Adapt::LevelType::curr,face_level);
+    adapt_.copy_face_level_curr(face_level);
 
   }
 
-  for (size_t i=0; i<child_face_level_curr_.size(); i++)
-    child_face_level_curr_[i] = 0;
+  std::fill(child_face_level_curr_.begin(),
+            child_face_level_curr_.end(), 0);
+
+  // Initialize face level counts
+  child_face_level_curr_count_.resize(nc*27);
+  std::fill(child_face_level_curr_count_.begin(),
+            child_face_level_curr_count_.end(), -1);
+
+  child_face_level_next_count_.resize(nc*27);
+  std::fill(child_face_level_next_count_.begin(),
+            child_face_level_next_count_.end(), -1);
 
   initialize_child_face_levels_();
 
@@ -316,6 +325,8 @@ void Block::pup(PUP::er &p)
   p | adapt_;
   p | child_face_level_curr_;
   p | child_face_level_next_;
+  p | child_face_level_curr_count_;
+  p | child_face_level_next_count_;
   p | count_coarsen_;
   p | adapt_step_;
   p | adapt_ready_;
@@ -436,34 +447,65 @@ void Block::print (FILE * fp_in) const
   fprintf (fp,"%d %s PRINT_BLOCK stop_ = %d\n",CkMyPe(),name_.c_str(),stop_);
   fprintf (fp,"%d %s PRINT_BLOCK index_initial_ = %d\n",CkMyPe(),name_.c_str(),index_initial_);
   fprintf (fp,"%d %s PRINT_BLOCK children_.size() = %lu\n",CkMyPe(),name_.c_str(),children_.size());
-  fprintf (fp,"%d %s PRINT_BLOCK child_face_level_curr_.size() = %lu\n",CkMyPe(),name_.c_str(),child_face_level_curr_.size());
-  for (std::size_t i=0; i<child_face_level_curr_.size(); i++) {fprintf (fp,"%d ",child_face_level_curr_[i]);} fprintf (fp,"\n");
+   fprintf (fp,"%d %s PRINT_BLOCK child_face_level_curr_.size() = %lu\n",CkMyPe(),name_.c_str(),child_face_level_curr_.size());
+  for (std::size_t i=0; i<child_face_level_curr_.size(); i++) {
+    fprintf (fp,"%d ",child_face_level_curr_[i]);
+  }
+  fprintf (fp,"\n");
+
   sync_coarsen_.print("PRINT_BLOCK",fp);
   fprintf (fp,"%d %s PRINT_BLOCK sync_count_ %d: ",
            CkMyPe(), name_.c_str(), (int)sync_count_.size());
-  for (std::size_t i=0; i<sync_count_.size(); i++) {fprintf (fp,"%d ",sync_count_[i]);} fprintf (fp,"\n");
+  for (std::size_t i=0; i<sync_count_.size(); i++) {
+    fprintf (fp,"%d ",sync_count_[i]);
+  }
+  fprintf (fp,"\n");
+
   fprintf (fp,"%d %s PRINT_BLOCK sync_max_ %d: ",
            CkMyPe(), name_.c_str(), (int)sync_max_.size());
-  for (std::size_t i=0; i<sync_max_.size(); i++) {fprintf (fp,"%d ",sync_max_[i]);} fprintf (fp,"\n");
+  for (std::size_t i=0; i<sync_max_.size(); i++)
+    {fprintf (fp,"%d ",sync_max_[i]);}
+  fprintf (fp,"\n");
+
   fprintf (fp,"%d %s PRINT_BLOCK child_face_level_next_.size() = %lu\n",CkMyPe(),name_.c_str(),child_face_level_next_.size());
-  for (std::size_t i=0; i<child_face_level_next_.size(); i++) {fprintf (fp,"%d ",child_face_level_next_[i]);} fprintf (fp,"\n");
 
-  fprintf (fp,"%d %s PRINT_BLOCK count_coarsen_ = %d\n",CkMyPe(),name_.c_str(),count_coarsen_);
-  fprintf (fp,"%d %s PRINT_BLOCK adapt_step_ = %d\n",CkMyPe(),name_.c_str(),adapt_step_);
-  fprintf (fp,"%d %s PRINT_BLOCK adapt_ready_ = %s\n",CkMyPe(),name_.c_str(),adapt_ready_?"true":"false");
-  fprintf (fp,"%d %s PRINT_BLOCK adapt_balanced_ = %s\n",CkMyPe(),name_.c_str(),adapt_balanced_?"true":"false");
-  fprintf (fp,"%d %s PRINT_BLOCK adapt_changed_ = %d\n",CkMyPe(),name_.c_str(),adapt_changed_);
-  fprintf (fp,"%d %s PRINT_BLOCK adapt_msg_list_.size() = %lu\n",CkMyPe(),name_.c_str(),adapt_msg_list_.size());
+  for (std::size_t i=0; i<child_face_level_next_.size(); i++){
+    fprintf (fp,"%d ",child_face_level_next_[i]);
+  }
+  fprintf (fp,"\n");
 
-  fprintf (fp,"%d %s PRINT_BLOCK coarsened_ = %d\n",CkMyPe(),name_.c_str(),coarsened_);
-  fprintf (fp,"%d %s PRINT_BLOCK is_leaf_ = %d\n",CkMyPe(),name_.c_str(),is_leaf_);
-  fprintf (fp,"%d %s PRINT_BLOCK age_ = %d\n",CkMyPe(),name_.c_str(),age_);
-  fprintf (fp,"%d %s PRINT_BLOCK ip_next_ = %d\n",CkMyPe(),name_.c_str(),ip_next_);
-  fprintf (fp,"%d %s PRINT_BLOCK index_method_ = %d\n",CkMyPe(),name_.c_str(),index_method_);
-  fprintf (fp,"%d %s PRINT_BLOCK index_solver_.size() = %lu\n",CkMyPe(),name_.c_str(),index_solver_.size());
+  fprintf (fp,"%d %s PRINT_BLOCK count_coarsen_ = %d\n",
+           CkMyPe(),name_.c_str(),count_coarsen_);
+  fprintf (fp,"%d %s PRINT_BLOCK adapt_step_ = %d\n",
+           CkMyPe(),name_.c_str(),adapt_step_);
+  fprintf (fp,"%d %s PRINT_BLOCK adapt_ready_ = %s\n",
+           CkMyPe(),name_.c_str(),adapt_ready_?"true":"false");
+  fprintf (fp,"%d %s PRINT_BLOCK adapt_balanced_ = %s\n",
+           CkMyPe(),name_.c_str(),adapt_balanced_?"true":"false");
+  fprintf (fp,"%d %s PRINT_BLOCK adapt_changed_ = %d\n",
+           CkMyPe(),name_.c_str(),adapt_changed_);
+  fprintf (fp,"%d %s PRINT_BLOCK adapt_msg_list_.size() = %lu\n",
+           CkMyPe(),name_.c_str(),adapt_msg_list_.size());
+
+  fprintf (fp,"%d %s PRINT_BLOCK coarsened_ = %d\n",
+           CkMyPe(),name_.c_str(),coarsened_);
+  fprintf (fp,"%d %s PRINT_BLOCK is_leaf_ = %d\n",
+           CkMyPe(),name_.c_str(),is_leaf_);
+  fprintf (fp,"%d %s PRINT_BLOCK age_ = %d\n",
+           CkMyPe(),name_.c_str(),age_);
+  fprintf (fp,"%d %s PRINT_BLOCK ip_next_ = %d\n",
+           CkMyPe(),name_.c_str(),ip_next_);
+  fprintf (fp,"%d %s PRINT_BLOCK index_method_ = %d\n",
+           CkMyPe(),name_.c_str(),index_method_);
+  fprintf (fp,"%d %s PRINT_BLOCK index_solver_.size() = %lu\n",
+           CkMyPe(),name_.c_str(),index_solver_.size());
+
   adapt_.print(std::string("Adapt-")+name_,this,fp);
 
-  for (std::size_t i=0; i<refresh_.size(); i++) { refresh_[i]->print(fp); }
+  for (std::size_t i=0; i<refresh_.size(); i++) {
+    refresh_[i]->print(fp);
+  }
+
 
   if (fp_in == nullptr) {
     fclose (fp);
@@ -666,6 +708,8 @@ Block::Block ()
     adapt_(),
     child_face_level_curr_(),
     child_face_level_next_(),
+    child_face_level_curr_count_(),
+    child_face_level_next_count_(),
     count_coarsen_(0),
     adapt_step_(0),
     adapt_ready_(false),
@@ -988,6 +1032,36 @@ void Block::is_on_boundary (bool is_boundary[3][2]) const throw()
       is_boundary[axis][face] =
 	index_.is_on_boundary(axis,2*face-1,n3[axis]);
     }
+  }
+}
+
+//----------------------------------------------------------------------
+
+void Block::set_child_face_level_curr
+(const int ic3[3], const int if3[3], int level, int count)
+{
+  int i = ICF3(ic3,if3);
+  if (count < 0) {
+    child_face_level_curr_count_[i] = count;
+  }
+  if (count >= child_face_level_curr_count_[i]) {
+    child_face_level_curr_[i]       = level;
+    child_face_level_curr_count_[i] = count;
+  }
+}
+
+//----------------------------------------------------------------------
+
+void Block::set_child_face_level_next
+(const int ic3[3], const int if3[3], int level, int count)
+{
+  int i = ICF3(ic3,if3);
+  if (count < 0) {
+    child_face_level_next_count_[i] = count;
+  }
+  if (count >= child_face_level_next_count_[i]) {
+    child_face_level_next_[i]       = level;
+    child_face_level_next_count_[i] = count;
   }
 }
 

--- a/src/Cello/mesh_Block.hpp
+++ b/src/Cello/mesh_Block.hpp
@@ -38,7 +38,7 @@ class Block : public CBase_Block
 public: // interface
 
   /// create a Block whose MsgRefine is on the creating process
-  Block ( process_type ip_source, MsgType msg_type );
+  Block ( MsgType msg_type );
   /// Initialize Block using MsgRefine returned by creating process
   virtual void p_set_msg_refine(MsgRefine * msg);
 
@@ -133,11 +133,10 @@ public: // interface
   { return index_; }
 
   int face_level (const int if3[3]) const
-  { return adapt_.face_level(if3,Adapt::LevelType::curr); }
+  { return adapt_.face_level_curr(if3); }
 
   int face_level (int axis, int face) const
-  { return adapt_.face_level(axis,face,Adapt::LevelType::curr); }
-
+  { return adapt_.face_level_curr(axis,face); }
 
   int child_face_level (const int ic3[3], const int if3[3]) const
   { return child_face_level_curr_[ICF3(ic3,if3)]; }
@@ -145,12 +144,19 @@ public: // interface
   int child_face_level_next (const int ic3[3], const int if3[3]) const
   { return child_face_level_next_[ICF3(ic3,if3)]; }
 
-  void set_child_face_level_curr (const int ic3[3], const int if3[3], int level)
-  { child_face_level_curr_[ICF3(ic3,if3)] = level;  }
+  void set_child_face_level_curr
+  (const int ic3[3], const int if3[3], int level, int count = -1);
 
-  void set_child_face_level_next (const int ic3[3], const int if3[3], int level)
-  { child_face_level_next_[ICF3(ic3,if3)] = level; }
+  void set_child_face_level_next
+  (const int ic3[3], const int if3[3], int level, int count = -1);
 
+  void clear_child_face_level_counts()
+  {
+    auto & curr_count = child_face_level_curr_count_;
+    std::fill(curr_count.begin(),curr_count.end(),-1);
+    auto & next_count = child_face_level_next_count_;
+    std::fill(next_count.begin(),next_count.end(),-1);
+  }
 
   /// Verify that new and old adapt neighbors match
   void verify_neighbors();
@@ -493,13 +499,14 @@ public:
    int ic3[3],
    std::vector<int> if3[3],
    int level_now, int level_new,
-   int level_max, bool can_coarsen);
-  
+   int level_max, bool can_coarsen,
+   int count);
+
   void p_adapt_recv_child (MsgCoarsen * msg);
 
   void adapt_recv (Index index_send, const int of3[3], const int ic3[3],
-		   int level_face_new, int level_relative,
-                   int level_max, bool can_coarsen);
+                   int level_face_new, int level_relative,
+                   int level_max, bool can_coarsen, int count);
 
   void adapt_send_level();
 
@@ -990,9 +997,11 @@ protected: // attributes
 
   /// current level of neighbors accumulated from children that can coarsen
   std::vector<int> child_face_level_curr_;
+  std::vector<int> child_face_level_curr_count_;
 
   /// new level of neighbors accumulated from children that can coarsen
   std::vector<int> child_face_level_next_;
+  std::vector<int> child_face_level_next_count_;
 
   /// Can coarsen only if all children can coarsen
   int count_coarsen_;

--- a/src/Cello/mesh_Index.hpp
+++ b/src/Cello/mesh_Index.hpp
@@ -101,18 +101,18 @@ public:
   bool is_root() const;
 
   /// Whether given `index` is a sibling (has the same parent as this Index)
-  bool is_sibling (Index index) const
+  bool is_sibling (Index index, int min_level = 0) const
   {
     const int level = this->level();
-    return (level >= 1 && index.level() >= 1) ?
-      (index_parent() == index.index_parent()) : false;
+    return (level >= min_level + 1 && index.level() >= min_level + 1) ?
+      (index_parent(min_level) == index.index_parent(min_level)) : false;
   }
   /// Whether given `index` is a "nibling" (child of a sibling of this Index)
-  bool is_nibling (Index index) const
+  bool is_nibling (Index index, int min_level = 0) const
   {
     const int level = this->level();
-    return (level >= 1 && index.level() >= 2) ?
-      (index_parent() == index.index_parent().index_parent()) : false;
+    return (level >= min_level + 1 && index.level() >= min_level + 2) ?
+      (index_parent(min_level) == index.index_parent(min_level).index_parent(min_level)) : false;
   }
 
   /// Return the dimensionality of shared face (0 corner, 1 edge, 2

--- a/src/Cello/simulation_Simulation.cpp
+++ b/src/Cello/simulation_Simulation.cpp
@@ -356,7 +356,7 @@ void Simulation::refine_create_block(MsgRefine * msg)
 
   msg_refine_map_[index] = msg;
 
-  cello::block_array()[index].insert(process_type(CkMyPe()),MsgType::msg_refine);
+  cello::block_array()[index].insert(MsgType::msg_refine);
 }
 
 //======================================================================
@@ -833,6 +833,12 @@ void Simulation::p_initial_block_created() throw() {
 void Simulation::p_set_block_array(CProxy_Block block_array)
 {
   if (CkMyPe() != 0) hierarchy_->set_block_array(block_array);
+  CkCallback callback
+    (CkIndex_Simulation::r_initialize_block_array(NULL), thisProxy);
+
+  // --------------------------------------------------
+  contribute(0,0,CkReduction::concat,callback);
+  // --------------------------------------------------
 }
 
 //----------------------------------------------------------------------

--- a/src/Cello/test_Adapt.cpp
+++ b/src/Cello/test_Adapt.cpp
@@ -114,7 +114,7 @@ PARALLEL_MAIN_BEGIN
       // initialize level bounds
       int min = level_want[i0];
       int now = level_curr[i0];
-      adapt[i0]->initialize_self (index[i0],min, now);
+      adapt[i0]->initialize_bounds (min, now);
       if (im >= 0) {
         adapt[i0]->insert_neighbor (index[im],(i0%2==1));
       }

--- a/src/Enzo/enzo-core/EnzoBlock.cpp
+++ b/src/Enzo/enzo-core/EnzoBlock.cpp
@@ -16,18 +16,16 @@
 
 //----------------------------------------------------------------------
 
-EnzoBlock::EnzoBlock (CkMigrateMessage *m)
+EnzoBlock::EnzoBlock( CkMigrateMessage *m)
   : CBase_EnzoBlock (m)
-    // dt(0.0),
-    // redshift(0.0)
 {
   TRACE("CkMigrateMessage");
   // EnzoSimulation[0] counts migrated Blocks
   proxy_enzo_simulation[0].p_method_balance_check();
 }
 
-EnzoBlock::EnzoBlock( process_type ip_source,  MsgType msg_type)
-  : CBase_EnzoBlock (ip_source, msg_type),
+EnzoBlock::EnzoBlock( MsgType msg_type)
+  : CBase_EnzoBlock (msg_type),
     redshift(0.0)
 
 {
@@ -280,6 +278,11 @@ void EnzoBlock::create_initial_child_blocks()
 
 void EnzoBlock::instantiate_children() throw()
 {
+#ifdef TRACE_BLOCK
+  CkPrintf ("%d %p :%d TRACE_BLOCK %s EnzoBlock instantiate_children()\n",
+            CkMyPe(),(void *)this,__LINE__,name(thisIndex).c_str());
+  fflush(stdout);
+#endif
   child_face_level_curr_.resize(cello::num_children()*27);
   int num_field_blocks = 1;
 

--- a/src/Enzo/enzo-core/EnzoBlock.hpp
+++ b/src/Enzo/enzo-core/EnzoBlock.hpp
@@ -35,7 +35,7 @@ public: // interface
 
   /// Initialize the EnzoBlock chare array
 
-  EnzoBlock ( process_type ip_source, MsgType msg_type );
+  EnzoBlock ( MsgType msg_type );
   /// Initialize EnzoBlock using MsgRefine returned by creating process
   void set_msg_refine(MsgRefine * msg);
   void set_msg_check(EnzoMsgCheck * msg);

--- a/src/Enzo/enzo-core/EnzoSimulation.cpp
+++ b/src/Enzo/enzo-core/EnzoSimulation.cpp
@@ -112,8 +112,7 @@ void EnzoSimulation::refine_create_block(MsgRefine * msg)
   }
   msg_refine_map_[index] = msg;
 
-  int ip = CkMyPe();
-  enzo::block_array()[index].insert(ip,MsgType::msg_refine,ip);
+  enzo::block_array()[index].insert(MsgType::msg_refine,CkMyPe());
 }
 
 //----------------------------------------------------------------------

--- a/src/Enzo/enzo.ci
+++ b/src/Enzo/enzo.ci
@@ -165,7 +165,7 @@ module enzo {
   //----------------------------------------------------------------------
   array[Index] EnzoBlock : Block {
 
-    entry EnzoBlock (process_type ip_source, MsgType msg_type);
+    entry EnzoBlock (MsgType msg_type);
 
     entry EnzoBlock();
  


### PR DESCRIPTION
Adapt
  - introduce counters to ensure messages processed in order sent
  - fixes adapt bug when Charm++ compiled with randomized queues
  - removed debugging code

Index
  - Added missing min_level parameter to is_sibling() and is_nibling()

Simulation
  - updated where block array stored so always created before accessed
